### PR TITLE
switch back to using a 204 when a resource is not available (instead of a 404)

### DIFF
--- a/src/Acme/DemoBundle/Controller/NoteController.php
+++ b/src/Acme/DemoBundle/Controller/NoteController.php
@@ -257,8 +257,7 @@ class NoteController extends FOSRestController
      * @ApiDoc(
      *   resource = true,
      *   statusCodes={
-     *     204="Returned when successful",
-     *     404="Returned when the note is not found"
+     *     204="Returned when successful"
      *   }
      * )
      *
@@ -266,19 +265,17 @@ class NoteController extends FOSRestController
      * @param int     $id      the note id
      *
      * @return RouteRedirectView
-     *
-     * @throws NotFoundHttpException when note not exist
      */
     public function deleteNotesAction(Request $request, $id)
     {
         $session = $request->getSession();
         $notes   = $session->get(self::SESSION_CONTEXT_NOTE);
-        if (!isset($notes[$id])) {
-            throw $this->createNotFoundException("Note does not exist.");
+        if (isset($notes[$id])) {
+            // There is a debate if this should be a 404 or a 204
+            // see http://leedavis81.github.io/is-a-http-delete-requests-idempotent/
+            unset($notes[$id]);
+            $session->set(self::SESSION_CONTEXT_NOTE, $notes);
         }
-
-        unset($notes[$id]);
-        $session->set(self::SESSION_CONTEXT_NOTE, $notes);
 
         return $this->routeRedirectView('get_notes', array(), Codes::HTTP_NO_CONTENT);
     }
@@ -289,8 +286,7 @@ class NoteController extends FOSRestController
      * @ApiDoc(
      *   resource = true,
      *   statusCodes={
-     *     204="Returned when successful",
-     *     404="Returned when the note is not found"
+     *     204="Returned when successful"
      *   }
      * )
      *
@@ -298,8 +294,6 @@ class NoteController extends FOSRestController
      * @param int     $id      the note id
      *
      * @return RouteRedirectView
-     *
-     * @throws NotFoundHttpException when note not exist
      */
     public function removeNotesAction(Request $request, $id)
     {

--- a/src/Acme/DemoBundle/Tests/Controller/NoteControllerTest.php
+++ b/src/Acme/DemoBundle/Tests/Controller/NoteControllerTest.php
@@ -156,7 +156,10 @@ class NoteControllerTest extends WebTestCase
         $client->request('GET', '/notes/0/remove.json');
         $response = $client->getResponse();
 
-        $this->assertJsonResponse($response, Codes::HTTP_NOT_FOUND);
+        $this->assertEquals(
+            Codes::HTTP_NO_CONTENT, $response->getStatusCode(),
+            $response->getContent()
+        );
 
         $this->createNote($client, 'my note for get');
 
@@ -174,7 +177,10 @@ class NoteControllerTest extends WebTestCase
         $client->request('DELETE', '/notes/0.json');
         $response = $client->getResponse();
 
-        $this->assertJsonResponse($response, Codes::HTTP_NOT_FOUND);
+        $this->assertEquals(
+            Codes::HTTP_NO_CONTENT, $response->getStatusCode(),
+            $response->getContent()
+        );
 
         $this->createNote($client, 'my note for get');
 


### PR DESCRIPTION
I still think that a 204 is the correct response in most cases for a DELETE on a non existent resource.

`How many systems have you built that actually know if some entity has existed that was deleted? Most systems do not know this, so a 410 would in fact be a lie or not .. the system would not have the information to give a proper answer. Now a 204 would be wrong if it would be interpreted as "yes I just deleted this", while to be it means "if there was anything that this location, then it is now gone". In an async world like the internet, this is what most system care about, that something is gone. If you receive a 404 it will confuse most clients into thinking it did something wrong, while the "something wrong" might have been the user(s) clicking on the same delete action multiple times before a response was received by the client. Now there might be systems where it does in fact matter that a specific action caused a delete and in such systems one would then have to track what entities have existed and then it might make sense to use a 404 but these are to me not the norm but the very very rare exception that need extra documentation. So I think we should default to 204 always.`

http://leedavis81.github.io/is-a-http-delete-requests-idempotent/#comment-1495098890
